### PR TITLE
add possibility to use custom bin-folder for composer

### DIFF
--- a/src/Command/RunCommand.php
+++ b/src/Command/RunCommand.php
@@ -15,6 +15,7 @@ use Symfony\Component\Process\Process;
 use TomasVotruba\PHPStanBodyscan\Exception\AnalysisFailedException;
 use TomasVotruba\PHPStanBodyscan\Logger;
 use TomasVotruba\PHPStanBodyscan\Process\AnalyseProcessFactory;
+use TomasVotruba\PHPStanBodyscan\Utils\ComposerLoader;
 use TomasVotruba\PHPStanBodyscan\Utils\FileLoader;
 use TomasVotruba\PHPStanBodyscan\Utils\JsonLoader;
 use TomasVotruba\PHPStanBodyscan\ValueObject\PHPStanLevelResult;
@@ -45,9 +46,10 @@ final class RunCommand extends Command
         $minPhpStanLevel = (int) $input->getOption('min-level');
         $maxPhpStanLevel = (int) $input->getOption('max-level');
         $projectDirectory = $input->getArgument('directory');
+        $binDirectory =  ComposerLoader::getBinDirectory($projectDirectory) ?? '/vendor/bin/';
 
         // 1. is phpstan installed in the project?
-        $this->ensurePHPStanIsInstalled($projectDirectory);
+        $this->ensurePHPStanIsInstalled($projectDirectory, $binDirectory);
 
         $envFile = $input->getOption('env-file');
         $envVariables = [];
@@ -157,9 +159,9 @@ final class RunCommand extends Command
             ->render();
     }
 
-    private function ensurePHPStanIsInstalled(string $projectDirectory): void
+    private function ensurePHPStanIsInstalled(string $projectDirectory, string $binDirectory): void
     {
-        if (! file_exists($projectDirectory . '/vendor/phpstan')) {
+        if (! file_exists($binDirectory . '/phpstan')) {
             $this->symfonyStyle->note('PHPStan not found in the project... installing');
             $requirePHPStanProcess = new Process([
                 'composer',

--- a/src/Command/RunCommand.php
+++ b/src/Command/RunCommand.php
@@ -46,7 +46,7 @@ final class RunCommand extends Command
         $minPhpStanLevel = (int) $input->getOption('min-level');
         $maxPhpStanLevel = (int) $input->getOption('max-level');
         $projectDirectory = $input->getArgument('directory');
-        $binDirectory =  ComposerLoader::getBinDirectory($projectDirectory) ?? '/vendor/bin/';
+        $binDirectory = ComposerLoader::getBinDirectory($projectDirectory) ?? '/vendor/bin/';
 
         // 1. is phpstan installed in the project?
         $this->ensurePHPStanIsInstalled($projectDirectory, $binDirectory);

--- a/src/Process/AnalyseProcessFactory.php
+++ b/src/Process/AnalyseProcessFactory.php
@@ -75,6 +75,10 @@ final class AnalyseProcessFactory
 
     private function resolvePhpStanBinFile(string $projectDirectory): string
     {
+        if (file_exists(ComposerLoader::getBinDirectory($projectDirectory) . '/phpstan')) {
+            return ComposerLoader::getBinDirectory($projectDirectory) . '/phpstan';
+        }
+
         if (file_exists($projectDirectory . '/vendor/bin/phpstan')) {
             return 'vendor/bin/phpstan';
         }

--- a/src/Process/AnalyseProcessFactory.php
+++ b/src/Process/AnalyseProcessFactory.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace TomasVotruba\PHPStanBodyscan\Process;
 
 use Symfony\Component\Process\Process;
+use TomasVotruba\PHPStanBodyscan\Utils\ComposerLoader;
 
 final class AnalyseProcessFactory
 {

--- a/src/Utils/ComposerLoader.php
+++ b/src/Utils/ComposerLoader.php
@@ -9,7 +9,11 @@ final class ComposerLoader
     public static function getBinDirectory(string $projectDirectory): ?string
     {
         $content = file_get_contents($projectDirectory . '/composer.json');
-        $content = json_decode($content,true);
-        return $content['config']['bin-dir'] ?? null;
+        if (is_string($content)) {
+            $content = json_decode($content, true);
+            return $content['config']['bin-dir'] ?? null;
+        }
+
+        return null;
     }
 }

--- a/src/Utils/ComposerLoader.php
+++ b/src/Utils/ComposerLoader.php
@@ -8,8 +8,8 @@ final class ComposerLoader
 {
     public static function getBinDirectory(string $projectDirectory): ?string
     {
-        $content = file_get_contents($projectDirectory , '/composer.json');
+        $content = file_get_contents($projectDirectory . '/composer.json');
         $content = json_decode($content,true);
-        return $content['config']['bin-dir'];
+        return $content['config']['bin-dir'] ?? null;
     }
 }

--- a/src/Utils/ComposerLoader.php
+++ b/src/Utils/ComposerLoader.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\PHPStanBodyscan\Utils;
+
+final class ComposerLoader
+{
+    public static function getBinDirectory(string $projectDirectory): ?string
+    {
+        $content = file_get_contents($projectDirectory , '/composer.json');
+        $content = json_decode($content,true);
+        return $content['config']['bin-dir'];
+    }
+}


### PR DESCRIPTION
This PR resolves issue #14. 

I still haven't tested it fully, as I get some errors when testing locally or with my fork as git repo. 

If I run it on my TYPO3 Crawler repository, which has a custom bin-folder, I get the following error. 

```sh
$ .Build/bin/phpstan-bodyscan

In JsonLoader.php line 20:
                                                                                        
  Could not decode JSON from phpstan: "At least one path must be specified to analyse.  
  "                                                                                     

In JsonLoader.php line 18:
                
  Syntax error  

```

The repository have a valid phpstan.neon file, so I don't know what I'm overlooking. 

I went for the simple implementation and used `file_get_content` of the `composer.json` to avoid pulling in an additional dependency. 
