### PR TITLE
Remove  `--no-ignore` from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,13 +56,6 @@ To get errors count per level:
 +-------+-------------+-----------;
 ```
 
-<br>
-
-## Do you want to run levels including all ignored messages?
-
-```bash
-vendor/bin/phpstan-bodyscan --no-ignore
-```
 
 <br>
 


### PR DESCRIPTION
Apparently, it was removed in e256f178bb1513db8630b48a4f6f50fd3ddb9a3e.